### PR TITLE
Show ratings page added

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,6 +22,11 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
+    @seller_items = Item.where(user_id: @item.user)
+    @ratings = Rating.where(item_id: @seller_items.ids)
+    @sum = 0
+    @ratings.each { |x| @sum += x.rating}
+    @seller_rating = @sum.to_f / @ratings.length()
   end
 
   def new

--- a/app/controllers/ratings_controller.rb
+++ b/app/controllers/ratings_controller.rb
@@ -24,6 +24,10 @@ class RatingsController < ApplicationController
     def see 
       @items = Item.where(user_id: current_user.id)
       @ratings = Rating.where(item_id: @items.ids)
+
+      @sum = 0
+      @ratings.each { |x| @sum += x.rating}
+      @seller_rating = @sum.to_f / @ratings.length()
     end
 
     private

--- a/app/controllers/ratings_controller.rb
+++ b/app/controllers/ratings_controller.rb
@@ -16,7 +16,11 @@ class RatingsController < ApplicationController
         render :new, status: :unprocessable_entity
       end
     end
-  
+
+    def show 
+      @ratings = Rating.where(user_id: current_user.id)
+    end
+
     private
   
     def check_purchase

--- a/app/controllers/ratings_controller.rb
+++ b/app/controllers/ratings_controller.rb
@@ -21,6 +21,11 @@ class RatingsController < ApplicationController
       @ratings = Rating.where(user_id: current_user.id)
     end
 
+    def see 
+      @items = Item.where(user_id: current_user.id)
+      @ratings = Rating.where(item_id: @items.ids)
+    end
+
     private
   
     def check_purchase

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -6,6 +6,7 @@
     <p><strong>Price:</strong> $<%= @item.price %></p>
     <p><strong>Condition:</strong> <%= @item.condition %></p>
     <p><strong>Seller:</strong> <%= @item.user.name %></p>
+    <p><strong>Seller rating:</strong> <%= @seller_rating %></p>
 </div>
 
 <% if @item.user_id == session[:user_id] %>
@@ -19,12 +20,12 @@
 
 <div id='separator'></div> 
 
-<% if @item.user_id != session[:user_id] %> 
-  <%= form_with model: @order, url: orders_path, method: :post do |form| %>
-    <%= form.hidden_field :item_id, value: @item.id %>  <!-- Passing item_id as a hidden field -->
-
-    <%= form.submit 'Place Order for Item' %>
-  <% end %>
+<% if current_cart.items.include?(@item) %>
+  <p><strong>Already in Cart</strong></p>
+<% elsif @item.user_id == current_user.id %>
+  <p><strong>This is your item</strong></p>
+<% else %>
+  <%= button_to 'Add to Cart', cart_add_item_path(cart_id: current_cart.id, item_id: @item.id), method: :post %>
 <% end %>
 <div id='separator'></div> 
 

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,7 +1,9 @@
 <h1>Orders</h1>
 
+<% num = 1 %>
 <% @orders.each do |order| %>
-  <h2>Order <%= order.id %></h2>
+  <h2>Order <%= num %></h2>
+  <% num += 1 %>
   <div class="items-grid">
       <% order.items.each do |item| %>
         <div class="item-card">

--- a/app/views/ratings/see.html.erb
+++ b/app/views/ratings/see.html.erb
@@ -4,8 +4,8 @@
 <div class="items-grid">
 <% @ratings.each do |rating| %>
     <div class="item-card">
-        <h2> Item: <%= rating.item.name %> </h2>
-        <p><strong>Seller:</strong> <%= rating.item.user.name %> </p>
+        <h2>Item: <%= rating.item.name %> </h2>
+        <p><strong>Reviewer:</strong> <%= rating.user.name %></p>
         <p><strong>Rating:</strong> <%= rating.rating %></p>
         <p><strong>Review:</strong> <%= rating.review %></p>
     </div>

--- a/app/views/ratings/see.html.erb
+++ b/app/views/ratings/see.html.erb
@@ -1,5 +1,6 @@
 <h1>Ratings</h1>
 
+<h2> Average rating: <%= @seller_rating %> <h2>
 <div class="center-display">
 <div class="items-grid">
 <% @ratings.each do |rating| %>

--- a/app/views/ratings/show.html.erb
+++ b/app/views/ratings/show.html.erb
@@ -5,7 +5,7 @@
 <% @ratings.each do |rating| %>
     <div class="item-card">
         <h2> Item: <%= rating.item.name %> </h2>
-        <p><strong>Seller:</strong> <%= rating.item.user.name %> </p>
+        <p><strong>Seller:</strong> <%= rating.item.user.name %></p>
         <p><strong>Rating:</strong> <%= rating.rating %></p>
         <p><strong>Review:</strong> <%= rating.review %></p>
     </div>

--- a/app/views/ratings/show.html.erb
+++ b/app/views/ratings/show.html.erb
@@ -1,0 +1,13 @@
+<h1>Ratings</h1>
+
+<div class="center-display">
+<div class="items-grid">
+<% @ratings.each do |rating| %>
+    <div class="item-card">
+    <h2>Item <%= rating.item.name %> by User <%= rating.item.user.name %> </h2>
+    <p><strong>Rating:</strong> <%= rating.rating %></p>
+    <p><strong>Review:</strong> <%= rating.review %></p>
+    </div>
+<% end %>
+</div>
+</div>

--- a/app/views/sessions/profile.html.erb
+++ b/app/views/sessions/profile.html.erb
@@ -1,6 +1,8 @@
 <h2>Test Profile</h2>
 
-<%= link_to "Orders", orders_path %>
+<%= link_to "Orders", orders_path %> |
+
+<%= link_to "Ratings you've given", ratings_path %>
 
 <h3> Your Current Listings: </h3>
 <div class="items-grid">

--- a/app/views/sessions/profile.html.erb
+++ b/app/views/sessions/profile.html.erb
@@ -2,7 +2,9 @@
 
 <%= link_to "Orders", orders_path %> |
 
-<%= link_to "Ratings you've given", ratings_path %>
+<%= link_to "Ratings you've given", ratings_path %> |
+
+<%= link_to "Your ratings", '/your_ratings' %>
 
 <h3> Your Current Listings: </h3>
 <div class="items-grid">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   end
 
   get '/ratings', to: 'ratings#show'
+  get '/your_ratings', to: 'ratings#see'
 
   get '*path', to: 'items#index'
   get "up" => "rails/health#show", as: :rails_health_check

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
     resources :ratings, only: [:new, :create]
   end
 
+  get '/ratings', to: 'ratings#show'
+
   get '*path', to: 'items#index'
   get "up" => "rails/health#show", as: :rails_health_check
 

--- a/node_modules/.yarn-integrity
+++ b/node_modules/.yarn-integrity
@@ -1,6 +1,8 @@
 {
-  "systemParams": "linux-x64-108",
-  "modulesFolders": [],
+  "systemParams": "linux-arm64-108",
+  "modulesFolders": [
+    "node_modules"
+  ],
   "flags": [],
   "linkedModules": [],
   "topLevelPatterns": [],


### PR DESCRIPTION
Added pages to see the ratings you've given and ratings given to your items. When viewing an item, you can now see the seller's average rating. You can also see your average rating on your profile.

There was a bug with placing orders on individual item. When navigating to an item's page, it gave you option to place an order on the item. This would add the item to your cart, but also create an empty order. This has been changed to only allowing the user to add an item to their cart.
